### PR TITLE
Copy + Format Changes to Gifts Page

### DIFF
--- a/docs/src/donate.md
+++ b/docs/src/donate.md
@@ -24,11 +24,10 @@ doing it. Don't worry if you can't donate. Merely using this strange, evolving
 creation is thanks enough. I love having you along for the ride, wherever it
 may take us.
 
-I have in my possession [21
-opendimes](https://www.youtube.com/watch?v=bLOlsa6K5TI) whose addresses are
-below.
+**Below are addresses for 21 opendimes belonging to me, Casey, the Ordinals Project lead.**
 
-Pick one that speaks to you, and send to it what you will.
+**Feel free to send Bitcoin AND/OR inscriptions to ANY of the following addresses to send a gift to the Ordinals core team. Your support is felt and appreciated!**
+
 
 Love,
 Casey


### PR DESCRIPTION
There has been some confusion within the Ordinals community about how to share gifts with the Ordinals Project core team. Specifically, people are confused about which wallet addresses they can safely send gifts to - and whether or not they can send Bitcoin and/or inscriptions to those wallet addresses safely. To address this confusion, I recommend making the following changes to the “Gifts” page at https://docs.ordinals.com/donate.html.